### PR TITLE
fix: use system browser for login instead of WKWebView

### DIFF
--- a/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
+++ b/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2026 tdhooghe
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import SwiftUI
+
+#if os(iOS)
+import AuthenticationServices
+#endif
+
+///
+/// Presents the Nextcloud Login Flow v2 authentication UI.
+///
+/// On **iOS**, this uses `ASWebAuthenticationSession` which opens a system browser sheet
+/// that properly handles cross-domain OIDC redirects, passkeys, and deep links.
+///
+/// On **macOS**, this presents a ``WebView`` in a sheet.
+///
+/// Credentials are obtained via the host app's polling mechanism on both platforms.
+///
+struct LoginSheet: ViewModifier {
+    let userAgent: String?
+    let onDismiss: () -> Void
+
+    @Binding var loginURL: URL?
+    @Binding var isPresented: Bool
+
+    #if os(iOS)
+    @State private var authSession: ASWebAuthenticationSession?
+    @State private var sessionCoordinator = SessionCoordinator()
+    #endif
+
+    init(loginURL: Binding<URL?>, isPresented: Binding<Bool>, userAgent: String?, onDismiss: @escaping () -> Void) {
+        self._loginURL = loginURL
+        self._isPresented = isPresented
+        self.userAgent = userAgent
+        self.onDismiss = onDismiss
+    }
+
+    func body(content: Content) -> some View {
+        content
+            #if os(macOS)
+            .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
+                WebView(initialURL: $loginURL, userAgent: userAgent)
+                    .ignoresSafeArea()
+                    .frame(minWidth: 800, minHeight: 800)
+            }
+            #else
+            .onChange(of: isPresented) { _, presented in
+                if presented, let url = loginURL {
+                    startAuthSession(url: url)
+                } else {
+                    authSession?.cancel()
+                    authSession = nil
+                }
+            }
+            #endif
+    }
+
+    #if os(iOS)
+
+    private func startAuthSession(url: URL) {
+        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: "nc") { _, error in
+            authSession = nil
+            if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
+                onDismiss()
+            }
+        }
+
+        session.presentationContextProvider = sessionCoordinator
+        session.prefersEphemeralWebBrowserSession = true
+        authSession = session
+        session.start()
+    }
+
+    #endif
+}
+
+extension View {
+    ///
+    /// Present the login authentication UI appropriate for the current platform.
+    ///
+    /// See ``LoginSheet`` for the implementation.
+    ///
+    func loginSheet(loginURL: Binding<URL?>, isPresented: Binding<Bool>, userAgent: String?, onDismiss: @escaping () -> Void) -> some View {
+        modifier(LoginSheet(loginURL: loginURL, isPresented: isPresented, userAgent: userAgent, onDismiss: onDismiss))
+    }
+}
+
+// MARK: - ASWebAuthenticationSession Coordinator
+
+#if os(iOS)
+
+///
+/// Provides the presentation anchor for `ASWebAuthenticationSession` in SwiftUI contexts.
+///
+@MainActor
+private class SessionCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return MainActor.assumeIsolated {
+            guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                  let window = windowScene.windows.first(where: \.isKeyWindow)
+            else {
+                return ASPresentationAnchor()
+            }
+            return window
+        }
+    }
+}
+
+#endif

--- a/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
+++ b/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
-// SPDX-FileCopyrightText: 2026 tdhooghe
+// SPDX-FileCopyrightText: 2025 tdhooghe
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import SwiftUI
@@ -97,7 +97,7 @@ extension View {
 @MainActor
 private class SessionCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
     nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return MainActor.assumeIsolated {
+        MainActor.assumeIsolated {
             guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
                   let window = windowScene.windows.first(where: \.isKeyWindow)
             else {

--- a/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
+++ b/Sources/SwiftNextcloudUI/Modifiers/LoginSheet.swift
@@ -4,108 +4,67 @@
 
 import SwiftUI
 
-#if os(iOS)
-import AuthenticationServices
-#endif
-
 ///
-/// Presents the Nextcloud Login Flow v2 authentication UI.
+/// Presents the Nextcloud Login Flow v2 authentication UI using the system browser.
 ///
-/// On **iOS**, this uses `ASWebAuthenticationSession` which opens a system browser sheet
-/// that properly handles cross-domain OIDC redirects, passkeys, and deep links.
+/// Uses SwiftUI's `webAuthenticationSession`, which handles cross-domain OIDC redirects,
+/// passkeys, and deep links on both iOS and macOS.
 ///
-/// On **macOS**, this presents a ``WebView`` in a sheet.
-///
-/// Credentials are obtained via the host app's polling mechanism on both platforms.
+/// Credentials are obtained via the host app's polling mechanism. The browser session has
+/// no callback to complete, so it is cancelled once polling reports success (when
+/// `isPresented` becomes `false`).
 ///
 struct LoginSheet: ViewModifier {
-    let userAgent: String?
+    @Environment(\.webAuthenticationSession) private var webAuthenticationSession
+
     let onDismiss: () -> Void
 
     @Binding var loginURL: URL?
     @Binding var isPresented: Bool
 
-    #if os(iOS)
-    @State private var authSession: ASWebAuthenticationSession?
-    @State private var sessionCoordinator = SessionCoordinator()
-    #endif
+    @State private var authenticationTask: Task<Void, Never>?
 
-    init(loginURL: Binding<URL?>, isPresented: Binding<Bool>, userAgent: String?, onDismiss: @escaping () -> Void) {
+    init(loginURL: Binding<URL?>, isPresented: Binding<Bool>, onDismiss: @escaping () -> Void) {
         self._loginURL = loginURL
         self._isPresented = isPresented
-        self.userAgent = userAgent
         self.onDismiss = onDismiss
     }
 
     func body(content: Content) -> some View {
-        content
-            #if os(macOS)
-            .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
-                WebView(initialURL: $loginURL, userAgent: userAgent)
-                    .ignoresSafeArea()
-                    .frame(minWidth: 800, minHeight: 800)
-            }
-            #else
-            .onChange(of: isPresented) { _, presented in
-                if presented, let url = loginURL {
-                    startAuthSession(url: url)
-                } else {
-                    authSession?.cancel()
-                    authSession = nil
-                }
-            }
-            #endif
-    }
-
-    #if os(iOS)
-
-    private func startAuthSession(url: URL) {
-        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: "nc") { _, error in
-            authSession = nil
-            if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
-                onDismiss()
+        content.onChange(of: isPresented) { _, presented in
+            if presented, let loginURL {
+                startAuthentication(url: loginURL)
+            } else {
+                authenticationTask?.cancel()
+                authenticationTask = nil
             }
         }
-
-        session.presentationContextProvider = sessionCoordinator
-        session.prefersEphemeralWebBrowserSession = true
-        authSession = session
-        session.start()
     }
 
-    #endif
+    private func startAuthentication(url: URL) {
+        authenticationTask = Task {
+            defer { authenticationTask = nil }
+            do {
+                _ = try await webAuthenticationSession.authenticate(
+                    using: url,
+                    callbackURLScheme: "nc",
+                    preferredBrowserSession: .ephemeral)
+            } catch {
+                if !Task.isCancelled {
+                    onDismiss()
+                }
+            }
+        }
+    }
 }
 
 extension View {
     ///
-    /// Present the login authentication UI appropriate for the current platform.
+    /// Present the Nextcloud login authentication UI using the system browser.
     ///
     /// See ``LoginSheet`` for the implementation.
     ///
-    func loginSheet(loginURL: Binding<URL?>, isPresented: Binding<Bool>, userAgent: String?, onDismiss: @escaping () -> Void) -> some View {
-        modifier(LoginSheet(loginURL: loginURL, isPresented: isPresented, userAgent: userAgent, onDismiss: onDismiss))
+    func loginSheet(loginURL: Binding<URL?>, isPresented: Binding<Bool>, onDismiss: @escaping () -> Void) -> some View {
+        modifier(LoginSheet(loginURL: loginURL, isPresented: isPresented, onDismiss: onDismiss))
     }
 }
-
-// MARK: - ASWebAuthenticationSession Coordinator
-
-#if os(iOS)
-
-///
-/// Provides the presentation anchor for `ASWebAuthenticationSession` in SwiftUI contexts.
-///
-@MainActor
-private class SessionCoordinator: NSObject, ASWebAuthenticationPresentationContextProviding {
-    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        MainActor.assumeIsolated {
-            guard let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-                  let window = windowScene.windows.first(where: \.isKeyWindow)
-            else {
-                return ASPresentationAnchor()
-            }
-            return window
-        }
-    }
-}
-
-#endif

--- a/Sources/SwiftNextcloudUI/Views/ServerAddressView.swift
+++ b/Sources/SwiftNextcloudUI/Views/ServerAddressView.swift
@@ -216,7 +216,7 @@ public struct ServerAddressView: View, QRCodeParsing, URLSanitizing {
             .safeAreaPadding(.all)
         }
         .ignoresSafeArea()
-        .loginSheet(loginURL: $loginAddress, isPresented: $isPresentingWebView, userAgent: userAgent, onDismiss: endWebView)
+        .loginSheet(loginURL: $loginAddress, isPresented: $isPresentingWebView, onDismiss: endWebView)
         .alert(String(localized: "Login Failed", comment: "Alert title"), isPresented: $isPresentingAlert) {
             Button(role: .cancel) {
                 errorMessage = nil

--- a/Sources/SwiftNextcloudUI/Views/ServerAddressView.swift
+++ b/Sources/SwiftNextcloudUI/Views/ServerAddressView.swift
@@ -216,7 +216,7 @@ public struct ServerAddressView: View, QRCodeParsing, URLSanitizing {
             .safeAreaPadding(.all)
         }
         .ignoresSafeArea()
-        .webSheet(initialURL: $loginAddress, isPresented: $isPresentingWebView, userAgent: userAgent, onDismiss: endWebView)
+        .loginSheet(loginURL: $loginAddress, isPresented: $isPresentingWebView, userAgent: userAgent, onDismiss: endWebView)
         .alert(String(localized: "Login Failed", comment: "Alert title"), isPresented: $isPresentingAlert) {
             Button(role: .cancel) {
                 errorMessage = nil
@@ -294,12 +294,12 @@ public struct ServerAddressView: View, QRCodeParsing, URLSanitizing {
     }
 
     ///
-    /// Dismisses the sheet with the web view.
+    /// Dismisses the login UI.
     ///
     /// Multiple paths can lead to here. In example:
     ///
-    /// - The user dismisses the sheet without logging in.
-    /// - The login completed successfully.
+    /// - The user dismisses the session without logging in.
+    /// - The login completed successfully (detected by polling).
     ///
     func endWebView() {
         if let pollingToken {


### PR DESCRIPTION
## Summary

`WKWebView` silently fails cross-domain OIDC redirects when Nextcloud delegates auth to an external IdP (Authentik, Keycloak, Azure AD): the user authenticates on the IdP, but `WKWebView` drops the callback redirect back to the Nextcloud origin, so Login Flow v2 polls forever.

This replaces the in-app `WKWebView` login with the system browser via SwiftUI's `webAuthenticationSession`, on both iOS and macOS. The system browser handles cross-domain OIDC redirects, passkeys/WebAuthn, and deep links. Credentials are still obtained via the host app's polling; no change to the polling API.

Same approach as the main iOS app (nextcloud/ios#3996), here in the shared package so consuming apps inherit it.

## Changes

- `LoginSheet.swift` (new): `ViewModifier` over `@Environment(\.webAuthenticationSession)`. The auth `Task` is held in `@State` and cancelled when `isPresented` becomes `false` (polling success), so the sheet doesn't linger. No `#if os` branches, no presentation-anchor coordinator (SwiftUI supplies it on both platforms).
- `ServerAddressView.swift`: `.webSheet(...)` → `.loginSheet(...)`. `userAgent` is no longer forwarded (the system browser can't set a custom UA); the public param is kept, and the app password name is unaffected since it comes from the host app's `/login/v2` request.

Closes #10

## Test plan

- iOS, local credentials (no OIDC): system browser opens, polling completes, logs in
- iOS, OIDC (e.g. Authentik): cross-domain redirect completes, polling picks up credentials
- iOS, cancel the sheet: returns to server address screen
- iOS, polling succeeds while sheet open: sheet auto-dismisses
- macOS: same cases via the system browser